### PR TITLE
chore: Upgrade kube-webhook-certgen

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -158,7 +158,7 @@ spec:
     spec:
       containers:
         - name: create
-          image: docker.io/jettech/kube-webhook-certgen:v1.5.1
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -188,7 +188,7 @@ spec:
     spec:
       containers:
         - name: patch
-          image: docker.io/jettech/kube-webhook-certgen:v1.5.1
+          image: k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.0
           imagePullPolicy: IfNotPresent
           args:
             - patch


### PR DESCRIPTION
Fixes #3 

Apparently the upstream is no longer maintained, switching to ingress-nginx fork https://github.com/jet/kube-webhook-certgen/issues/30